### PR TITLE
StreamUpdatesOn refactor

### DIFF
--- a/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Base/ChatEntity.cs
+++ b/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Base/ChatEntity.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using PubnubApi;
 
@@ -32,9 +33,19 @@ namespace PubnubChatApi
             }
         }
         
-        public virtual void SetListeningForUpdates(bool listen)
+        [Obsolete("Obsolete, please use StreamUpdates() instead")]
+        public void SetListeningForUpdates(bool listen)
         {
-            SetListening(ref updateSubscription, SubscriptionOptions.None, listen, UpdateChannelId, CreateUpdateListener());
+            StreamUpdates(listen);
+        }
+        
+        /// <summary>
+        /// Sets whether to listen for update events on this entity.
+        /// </summary>
+        /// <param name="stream">True to start listening, false to stop listening.</param>
+        public void StreamUpdates(bool stream)
+        {
+            SetListening(ref updateSubscription, SubscriptionOptions.None, stream, UpdateChannelId, CreateUpdateListener());
         }
         
         protected abstract SubscribeCallback CreateUpdateListener();

--- a/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Chat.cs
+++ b/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Chat.cs
@@ -121,6 +121,7 @@ namespace PubnubChatApi
         /// </summary>
         /// <param name="channelIds">List of channel IDs to listen to.</param>
         /// <param name="listener">The listener callback to invoke on channel updates.</param>
+        [Obsolete("Obsolete, please use the static Channel.StreamUpdatesOn() instead")]
         public async Task AddListenerToChannelsUpdate(List<string> channelIds, Action<Channel> listener)
         {
             foreach (var channelId in channelIds)
@@ -776,6 +777,7 @@ namespace PubnubChatApi
         /// </summary>
         /// <param name="userIds">List of user IDs to listen to.</param>
         /// <param name="listener">The listener callback to invoke on user updates.</param>
+        [Obsolete("Obsolete, please use the static User.StreamUpdatesOn() instead")]
         public async void AddListenerToUsersUpdate(List<string> userIds, Action<User> listener)
         {
             foreach (var userId in userIds)
@@ -1531,6 +1533,7 @@ namespace PubnubChatApi
         /// <param name="channelId">The ID of the channel containing the messages.</param>
         /// <param name="messageTimeTokens">List of message time tokens to listen to for updates.</param>
         /// <param name="listener">The listener callback to invoke on message updates.</param>
+        [Obsolete("Obsolete, please use the static Message.StreamUpdatesOn() instead")]
         public async void AddListenerToMessagesUpdate(string channelId, List<string> messageTimeTokens,
             Action<Message> listener)
         {

--- a/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Message.cs
+++ b/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Message.cs
@@ -255,6 +255,38 @@ namespace PubnubChatApi
                 }
             });
         }
+        
+        /// <summary>
+        /// Adds a listener for message update events on multiple messages.
+        /// The callback will be invoked with all messages each time any one of them receives an update.
+        /// </summary>
+        /// <param name="messages">List of messages to listen to.</param>
+        /// <param name="listener">The listener callback to invoke on message updates.</param>
+        public static void StreamUpdatesOn(List<Message> messages, Action<List<Message>> listener){
+            foreach (var message in messages)
+            {
+                message.StreamUpdates(true);
+                message.OnMessageUpdated += delegate { listener.Invoke(messages); };
+            }
+        }
+        
+        /// <summary>
+        /// <para>
+        /// Adds a listener for message update events on multiple messages.
+        /// The callback is invoked with the Message that was just updated and the type of update it experienced.
+        /// </para>
+        /// <b>WARNING</b>: Messages currently don't receive hard deletion callbacks, so only Delete(soft:true) will yield a
+        /// callback with ChatEntityChangeType "Updated"
+        /// </summary>
+        /// <param name="messages">List of messages to listen to.</param>
+        /// <param name="listener">The listener callback to invoke on message updates.</param>
+        public static void StreamUpdatesOn(List<Message> messages, Action<Message, ChatEntityChangeType> listener){
+            foreach (var message in messages)
+            {
+                message.StreamUpdates(true);
+                message.OnMessageUpdated += delegate { listener.Invoke(message, ChatEntityChangeType.Updated); };
+            }
+        }
 
         /// <summary>
         /// Edits the text of the message.

--- a/c-sharp-chat/PubnubChatApi/PubnubChatApi/Enums/ChatEntityChangeType.cs
+++ b/c-sharp-chat/PubnubChatApi/PubnubChatApi/Enums/ChatEntityChangeType.cs
@@ -1,0 +1,8 @@
+namespace PubnubChatApi
+{
+    public enum ChatEntityChangeType
+    {
+        Updated,
+        Deleted
+    }
+}

--- a/c-sharp-chat/PubnubChatApi/PubnubChatApi/Utilities/ChatParsers.cs
+++ b/c-sharp-chat/PubnubChatApi/PubnubChatApi/Utilities/ChatParsers.cs
@@ -83,13 +83,19 @@ namespace PubnubChatApi
             }
         }
 
-        internal static bool TryParseMembershipUpdate(Chat chat, Membership membership, PNObjectEventResult objectEvent, out ChatMembershipData updatedData)
+        internal static bool TryParseMembershipUpdate(Chat chat, Membership membership, PNObjectEventResult objectEvent, out ChatMembershipData updatedData, out ChatEntityChangeType changeType)
         {
             try
             {
                 var channel = objectEvent.MembershipMetadata.Channel;
                 var user = objectEvent.MembershipMetadata.Uuid;
                 var type = objectEvent.Type;
+                changeType = objectEvent.Event switch
+                {
+                    "set" => ChatEntityChangeType.Updated,
+                    "delete" => ChatEntityChangeType.Deleted,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
                 if (type == "membership" && channel == membership.ChannelId && user == membership.UserId)
                 {
                     updatedData = new ChatMembershipData()
@@ -110,16 +116,23 @@ namespace PubnubChatApi
             {
                 chat.Logger.Debug($"Failed to parse PNObjectEventResult of type: {objectEvent.Event} into Membership update. Exception was: {e.Message}");
                 updatedData = null;
+                changeType = default;
                 return false;
             }
         }
         
-        internal static bool TryParseUserUpdate(Chat chat, User user, PNObjectEventResult objectEvent, out ChatUserData updatedData)
+        internal static bool TryParseUserUpdate(Chat chat, User user, PNObjectEventResult objectEvent, out ChatUserData updatedData, out ChatEntityChangeType changeType)
         {
             try
             {
                 var uuid = objectEvent.UuidMetadata.Uuid;
                 var type = objectEvent.Type;
+                changeType = objectEvent.Event switch
+                {
+                    "set" => ChatEntityChangeType.Updated,
+                    "delete" => ChatEntityChangeType.Deleted,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
                 if (type == "uuid" && uuid == user.Id)
                 {
                     updatedData = objectEvent.UuidMetadata;
@@ -135,16 +148,23 @@ namespace PubnubChatApi
             {
                 chat.Logger.Debug($"Failed to parse PNObjectEventResult of type: {objectEvent.Event} into User update. Exception was: {e.Message}");
                 updatedData = null;
+                changeType = default;
                 return false;
             }
         }
         
-        internal static bool TryParseChannelUpdate(Chat chat, Channel channel, PNObjectEventResult objectEvent, out ChatChannelData updatedData)
+        internal static bool TryParseChannelUpdate(Chat chat, Channel channel, PNObjectEventResult objectEvent, out ChatChannelData updatedData, out ChatEntityChangeType changeType)
         {
             try
             {
                 var channelId = objectEvent.Channel;
                 var type = objectEvent.Type;
+                changeType = objectEvent.Event switch
+                {
+                    "set" => ChatEntityChangeType.Updated,
+                    "delete" => ChatEntityChangeType.Deleted,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
                 if (type == "channel" && channelId == channel.Id)
                 {
                     updatedData = objectEvent.ChannelMetadata;
@@ -160,6 +180,7 @@ namespace PubnubChatApi
             {
                 chat.Logger.Debug($"Failed to parse PNObjectEventResult of type: {objectEvent.Event} into Channel update. Exception was: {e.Message}");
                 updatedData = null;
+                changeType = default;
                 return false;
             }
         }

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Base/ChatEntity.cs
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Base/ChatEntity.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using PubnubApi;
 
@@ -32,9 +33,19 @@ namespace PubnubChatApi
             }
         }
         
-        public virtual void SetListeningForUpdates(bool listen)
+        [Obsolete("Obsolete, please use StreamUpdates() instead")]
+        public void SetListeningForUpdates(bool listen)
         {
-            SetListening(ref updateSubscription, SubscriptionOptions.None, listen, UpdateChannelId, CreateUpdateListener());
+            StreamUpdates(listen);
+        }
+        
+        /// <summary>
+        /// Sets whether to listen for update events on this entity.
+        /// </summary>
+        /// <param name="stream">True to start listening, false to stop listening.</param>
+        public void StreamUpdates(bool stream)
+        {
+            SetListening(ref updateSubscription, SubscriptionOptions.None, stream, UpdateChannelId, CreateUpdateListener());
         }
         
         protected abstract SubscribeCallback CreateUpdateListener();

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Chat.cs
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Chat.cs
@@ -121,6 +121,7 @@ namespace PubnubChatApi
         /// </summary>
         /// <param name="channelIds">List of channel IDs to listen to.</param>
         /// <param name="listener">The listener callback to invoke on channel updates.</param>
+        [Obsolete("Obsolete, please use the static Channel.StreamUpdatesOn() instead")]
         public async Task AddListenerToChannelsUpdate(List<string> channelIds, Action<Channel> listener)
         {
             foreach (var channelId in channelIds)
@@ -776,6 +777,7 @@ namespace PubnubChatApi
         /// </summary>
         /// <param name="userIds">List of user IDs to listen to.</param>
         /// <param name="listener">The listener callback to invoke on user updates.</param>
+        [Obsolete("Obsolete, please use the static User.StreamUpdatesOn() instead")]
         public async void AddListenerToUsersUpdate(List<string> userIds, Action<User> listener)
         {
             foreach (var userId in userIds)
@@ -1531,6 +1533,7 @@ namespace PubnubChatApi
         /// <param name="channelId">The ID of the channel containing the messages.</param>
         /// <param name="messageTimeTokens">List of message time tokens to listen to for updates.</param>
         /// <param name="listener">The listener callback to invoke on message updates.</param>
+        [Obsolete("Obsolete, please use the static Message.StreamUpdatesOn() instead")]
         public async void AddListenerToMessagesUpdate(string channelId, List<string> messageTimeTokens,
             Action<Message> listener)
         {

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Message.cs
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Message.cs
@@ -255,6 +255,38 @@ namespace PubnubChatApi
                 }
             });
         }
+        
+        /// <summary>
+        /// Adds a listener for message update events on multiple messages.
+        /// The callback will be invoked with all messages each time any one of them receives an update.
+        /// </summary>
+        /// <param name="messages">List of messages to listen to.</param>
+        /// <param name="listener">The listener callback to invoke on message updates.</param>
+        public static void StreamUpdatesOn(List<Message> messages, Action<List<Message>> listener){
+            foreach (var message in messages)
+            {
+                message.StreamUpdates(true);
+                message.OnMessageUpdated += delegate { listener.Invoke(messages); };
+            }
+        }
+        
+        /// <summary>
+        /// <para>
+        /// Adds a listener for message update events on multiple messages.
+        /// The callback is invoked with the Message that was just updated and the type of update it experienced.
+        /// </para>
+        /// <b>WARNING</b>: Messages currently don't receive hard deletion callbacks, so only Delete(soft:true) will yield a
+        /// callback with ChatEntityChangeType "Updated"
+        /// </summary>
+        /// <param name="messages">List of messages to listen to.</param>
+        /// <param name="listener">The listener callback to invoke on message updates.</param>
+        public static void StreamUpdatesOn(List<Message> messages, Action<Message, ChatEntityChangeType> listener){
+            foreach (var message in messages)
+            {
+                message.StreamUpdates(true);
+                message.OnMessageUpdated += delegate { listener.Invoke(message, ChatEntityChangeType.Updated); };
+            }
+        }
 
         /// <summary>
         /// Edits the text of the message.

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Enums/ChatEntityChangeType.cs
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Enums/ChatEntityChangeType.cs
@@ -1,0 +1,8 @@
+namespace PubnubChatApi
+{
+    public enum ChatEntityChangeType
+    {
+        Updated,
+        Deleted
+    }
+}

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Enums/ChatEntityChangeType.cs.meta
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Enums/ChatEntityChangeType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d70d78c7954de914fa4ceeb7215f44aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Utilities/ChatParsers.cs
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Utilities/ChatParsers.cs
@@ -83,13 +83,19 @@ namespace PubnubChatApi
             }
         }
 
-        internal static bool TryParseMembershipUpdate(Chat chat, Membership membership, PNObjectEventResult objectEvent, out ChatMembershipData updatedData)
+        internal static bool TryParseMembershipUpdate(Chat chat, Membership membership, PNObjectEventResult objectEvent, out ChatMembershipData updatedData, out ChatEntityChangeType changeType)
         {
             try
             {
                 var channel = objectEvent.MembershipMetadata.Channel;
                 var user = objectEvent.MembershipMetadata.Uuid;
                 var type = objectEvent.Type;
+                changeType = objectEvent.Event switch
+                {
+                    "set" => ChatEntityChangeType.Updated,
+                    "delete" => ChatEntityChangeType.Deleted,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
                 if (type == "membership" && channel == membership.ChannelId && user == membership.UserId)
                 {
                     updatedData = new ChatMembershipData()
@@ -110,16 +116,23 @@ namespace PubnubChatApi
             {
                 chat.Logger.Debug($"Failed to parse PNObjectEventResult of type: {objectEvent.Event} into Membership update. Exception was: {e.Message}");
                 updatedData = null;
+                changeType = default;
                 return false;
             }
         }
         
-        internal static bool TryParseUserUpdate(Chat chat, User user, PNObjectEventResult objectEvent, out ChatUserData updatedData)
+        internal static bool TryParseUserUpdate(Chat chat, User user, PNObjectEventResult objectEvent, out ChatUserData updatedData, out ChatEntityChangeType changeType)
         {
             try
             {
                 var uuid = objectEvent.UuidMetadata.Uuid;
                 var type = objectEvent.Type;
+                changeType = objectEvent.Event switch
+                {
+                    "set" => ChatEntityChangeType.Updated,
+                    "delete" => ChatEntityChangeType.Deleted,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
                 if (type == "uuid" && uuid == user.Id)
                 {
                     updatedData = objectEvent.UuidMetadata;
@@ -135,16 +148,23 @@ namespace PubnubChatApi
             {
                 chat.Logger.Debug($"Failed to parse PNObjectEventResult of type: {objectEvent.Event} into User update. Exception was: {e.Message}");
                 updatedData = null;
+                changeType = default;
                 return false;
             }
         }
         
-        internal static bool TryParseChannelUpdate(Chat chat, Channel channel, PNObjectEventResult objectEvent, out ChatChannelData updatedData)
+        internal static bool TryParseChannelUpdate(Chat chat, Channel channel, PNObjectEventResult objectEvent, out ChatChannelData updatedData, out ChatEntityChangeType changeType)
         {
             try
             {
                 var channelId = objectEvent.Channel;
                 var type = objectEvent.Type;
+                changeType = objectEvent.Event switch
+                {
+                    "set" => ChatEntityChangeType.Updated,
+                    "delete" => ChatEntityChangeType.Deleted,
+                    _ => throw new ArgumentOutOfRangeException()
+                };
                 if (type == "channel" && channelId == channel.Id)
                 {
                     updatedData = objectEvent.ChannelMetadata;
@@ -160,6 +180,7 @@ namespace PubnubChatApi
             {
                 chat.Logger.Debug($"Failed to parse PNObjectEventResult of type: {objectEvent.Event} into Channel update. Exception was: {e.Message}");
                 updatedData = null;
+                changeType = default;
                 return false;
             }
         }

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/CustomEventsSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/CustomEventsSample.cs
@@ -82,8 +82,8 @@ public class CustomEventsSample
             SendResponseToCustomerChat(customerID, timestamp, response);
         }
 
-        // example event listener using "SetListeningForCustomEvents()" on some channel
-        channel.SetListeningForCustomEvents(true);
+        // example event listener using "StreamCustomEvents()" on some channel
+        channel.StreamCustomEvents(true);
         channel.OnCustomEvent += customEvent => 
         {
              if(customEvent.Payload.Contains("\"triggerWord\":\frustrated\""))

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/InviteChannelSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/InviteChannelSample.cs
@@ -105,7 +105,7 @@ public class InviteChannelSample
         var user = userResult.Result;
 
         //start listening
-        user.SetListeningForInviteEvents(true);
+        user.StreamInviteEvents(true);
         //lambda event handler
         user.OnInviteEvent += (inviteEvent) => 
             {

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/MembershipChannelSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/MembershipChannelSample.cs
@@ -86,7 +86,7 @@ public class MembershipChannelSample
                     Debug.Log($"First membership for user {user.UserName} is in channel {firstMembership.ChannelId}");
                     
                     // start listening for updates on memberships
-                    firstMembership.SetListeningForUpdates(true);
+                    firstMembership.StreamUpdates(true);
                     
                     // attach an event handler for membership updates
                     firstMembership.OnMembershipUpdated += OnMembershipUpdatedHandler;

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/MentionsUserSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/MentionsUserSample.cs
@@ -161,7 +161,7 @@ public class MentionsUserSample
             return;
         }
         var user = userResult.Result;
-        user.SetListeningForMentionEvents(true);
+        user.StreamMentionEvents(true);
         user.OnMentionEvent += mentionEvent => 
         {
             if(mentionEvent.ChannelId == "support")

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/ModerationMessageSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/ModerationMessageSample.cs
@@ -80,7 +80,7 @@ public class ModerationMessageSample
             return;
         }
         var channel = channelResult.Result;
-        channel.SetListeningForReportEvents(true);
+        channel.StreamReportEvents(true);
         channel.OnReportEvent += reportEvent => 
         {
             Debug.Log("Message reported on the support channel!");

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/ModerationUserSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/ModerationUserSample.cs
@@ -244,7 +244,7 @@ public class ModerationUserSample
         }
         var user = userResult.Result;
 
-        user.SetListeningForModerationEvents(true);
+        user.StreamModerationEvents(true);
 
         user.OnModerationEvent += OnModerationEventHandler; // or use lambda
 

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/ReadReceiptsMessageSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/ReadReceiptsMessageSample.cs
@@ -45,7 +45,7 @@ public class ReadReceiptsMessageSample
 
             // join the channel and start listening to read receipt events
             await channel.Join();
-            channel.SetListeningForReadReceiptsEvents(true);
+            channel.StreamReadReceipts(true);
 
             // subscribe to the OnReadReceiptEvent event
             channel.OnReadReceiptEvent += OnReadHandler;

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/TypingIndicatorSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/TypingIndicatorSample.cs
@@ -77,7 +77,7 @@ public class TypingIndicatorSample
 
             // join the channel, start listening for typing
             await channel.Join();
-            channel.SetListeningForTyping(true);
+            channel.StreamTyping(true);
 
             // subscribe to the OnUsersTyping event
             channel.OnUsersTyping += OnUsersTypingHandler;

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/UpdatesChannelSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/UpdatesChannelSample.cs
@@ -77,7 +77,7 @@ public class UpdatesChannelSample
             return;
         }
         var channel = channelResult.Result;
-        channel.SetListeningForUpdates(true);
+        channel.StreamUpdates(true);
         channel.OnChannelUpdate += OnChannelUpdateHandler; // or use lambda
 
         void OnChannelUpdateHandler(Channel channel)
@@ -90,14 +90,22 @@ public class UpdatesChannelSample
     public static async Task AddListenerToChannelsUpdateExample()
     {
         // snippet.add_listener_to_channels_update_example
-        List<string> channelIds = new List<string> { "support", "incidentManagement" };
-        Action<Channel> listener = (Channel channel) => 
+        var channels = new List<Channel>();
+        var channel1 = await chat.GetChannel("support");
+        var channel2 = await chat.GetChannel("incidentManagement");
+        if (!channel1.Error && !channel2.Error)
+        {
+            channels.Add(channel1.Result);
+            channels.Add(channel2.Result);
+        }
+        Action<Channel, ChatEntityChangeType> listener = (channel, changeType) => 
             {
-                // Print the updated channel name
+                // Print the updated channel name and the change type
                 Debug.Log("Updated Channel Name: " + channel.Name);
+                Debug.Log("Channel update type: " + changeType);
             };
 
-        await chat.AddListenerToChannelsUpdate(channelIds, listener);
+        Channel.StreamUpdatesOn(channels, listener);
         // snippet.end
     }
 }

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/UpdatesMessageSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/UpdatesMessageSample.cs
@@ -59,7 +59,7 @@ public class UpdatesMessageSample
             return;
         }
         var message = messageResult.Result.First();
-        message.SetListeningForUpdates(true);
+        message.StreamUpdates(true);
         message.OnMessageUpdated += OnMessageUpdatedHandler; // or use lambda
 
         void OnMessageUpdatedHandler(Message message)
@@ -87,25 +87,14 @@ public class UpdatesMessageSample
             return;
         }
         var messages = messagesResult.Result;
-
-        List<string> timetokens = new List<string>();
         
-        // get the timetokens
-        foreach (var message in messages)
+        // WARNING: Messages currently don't receive hard deletion callbacks, so only Delete(soft:true) will yield a
+        // callback with ChatEntityChangeType "Updated"
+        void OnMessageUpdatedHandler(Message message, ChatEntityChangeType chatEntityChangeType)
         {
-            // Get the time token of the current message
-            string timeToken = message.TimeToken;
-            
-            // Add the time token to the list
-            timetokens.Add(timeToken);
+            Debug.Log($"Message with timetoken {message.TimeToken} updated! Change type: {chatEntityChangeType}");
         }
-        
-        void OnMessageUpdatedHandler(Message message)
-        {
-            Debug.Log($"Message updated");
-        }
-
-        chat.AddListenerToMessagesUpdate(channelId: "support", messageTimeTokens: timetokens, listener: OnMessageUpdatedHandler);
+        Message.StreamUpdatesOn(messages, OnMessageUpdatedHandler);
         // snippet.end
     }
 }

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/UpdatesUserSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/UpdatesUserSample.cs
@@ -74,7 +74,7 @@ public class UpdatesUserSample
         }
         var user = userResult.Result;
         
-        user.SetListeningForUpdates(true);
+        user.StreamUpdates(true);
       
         user.OnUserUpdated += OnUserUpdatedHandler; // or use lambda
         void OnUserUpdatedHandler(User user)
@@ -87,13 +87,21 @@ public class UpdatesUserSample
     public static async Task AddListenerToUsersUpdateExample()
     {
         // snippet.add_listener_to_users_update_example
-        List<string> users = new List<string> { "support_agent_15", "support-manager" };
-        Action<User> listener = (User user) => 
+        var users = new List<User>();
+        var getFirstUser = await chat.GetUser("support-agent-1");
+        var getSecondUser = await chat.GetUser("support-agent-2");
+        if (!getFirstUser.Error && !getSecondUser.Error)
         {
-            // Print the updated user name
+            users.Add(getFirstUser.Result);
+            users.Add(getSecondUser.Result);
+        }
+        Action<User, ChatEntityChangeType> listener = (user, changeType) => 
+        {
+            // Print the updated user name and the type of update
             Debug.Log("Updated user Name: " + user.UserName);
+            Debug.Log("Update type: " + changeType);
         };
-        chat.AddListenerToUsersUpdate(users, listener);
+        User.StreamUpdatesOn(users, listener);
         // snippet.end
     }
 }


### PR DESCRIPTION
refactor: deprecated old streaming methods

Changed SetListening(...) and AddListenerTo(...) methods to align with other Chat SDKs. New methods are use the "Stream" and "StreamOn" naming convetions

feat: added and implemented ChatEntityChangeType enum

Added new overloads for update related methods and events so that they now use ChatEntityChangeType to convey the type of update.