### PR TITLE
Implement the "pending" status for Memberships created from Invites

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -5,11 +5,11 @@ changelog:
     version: v1.2.0
     changes:
       - type: feature
-        text: "Memberships generated from Invite methods now have Status = "pending" and can be filtered out in GetMemberships()."
+        text: "Memberships generated from Invite methods now have Status pending and can be filtered out in GetMemberships()."
       - type: feature
         text: "Added new overloads for update related methods and events so that they now use ChatEntityChangeType to convey the type of update."
       - type: improvement
-        text: "Changed SetListening(...) and AddListenerTo(...) methods to align with other Chat SDKs. New methods are use the "Stream" and "StreamOn" naming convetions."
+        text: "Changed SetListening(...) and AddListenerTo(...) methods to align with other Chat SDKs. New methods are use the Stream and StreamOn naming convetions."
   - date: 2025-11-06
     version: v1.1.1
     changes:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,6 +1,15 @@
 --- 
-version: v1.1.1
+version: v1.2.0
 changelog:
+  - date: 2025-11-24
+    version: v1.2.0
+    changes:
+      - type: feature
+        text: "Memberships generated from Invite methods now have Status = "pending" and can be filtered out in GetMemberships()."
+      - type: feature
+        text: "Added new overloads for update related methods and events so that they now use ChatEntityChangeType to convey the type of update."
+      - type: improvement
+        text: "Changed SetListening(...) and AddListenerTo(...) methods to align with other Chat SDKs. New methods are use the "Stream" and "StreamOn" naming convetions."
   - date: 2025-11-06
     version: v1.1.1
     changes:

--- a/c-sharp-chat/PubnubChatApi/PubNubChatApi.Tests/ChannelTests.cs
+++ b/c-sharp-chat/PubnubChatApi/PubNubChatApi.Tests/ChannelTests.cs
@@ -170,6 +170,35 @@ public class ChannelTests
     }
 
     [Test]
+    public async Task TestGetInvitees()
+    {
+        var channel = TestUtils.AssertOperation(await chat.CreatePublicConversation());
+        await channel.Invite(user);
+        await Task.Delay(3500);
+        var invitees = TestUtils.AssertOperation(await channel.GetInvitees());
+        Assert.True(invitees.Memberships.Any(x => x.UserId == user.Id && x.ChannelId == channel.Id && x.MembershipData.Status == "pending"));
+        
+        //Cleanup
+        await channel.Delete();
+    }
+
+    [Test]
+    public async Task TestInviteAndJoin()
+    {
+        var channel = TestUtils.AssertOperation(await chat.CreatePublicConversation());
+        await channel.Invite(user);
+        await Task.Delay(3500);
+        var invitees = TestUtils.AssertOperation(await channel.GetInvitees());
+        Assert.True(invitees.Memberships.Any(x => x.UserId == user.Id && x.ChannelId == channel.Id && x.MembershipData.Status == "pending"));
+        await channel.Join();
+        await Task.Delay(3500);
+        invitees = TestUtils.AssertOperation(await channel.GetInvitees());
+        Assert.False(invitees.Memberships.Any());
+        var members = TestUtils.AssertOperation(await channel.GetMemberships());
+        Assert.True(members.Memberships.Any(x => x.UserId == user.Id && x.ChannelId == channel.Id && x.MembershipData.Status != "pending"));
+    }
+
+    [Test]
     public async Task TestStartTyping()
     {
         var channel = TestUtils.AssertOperation(await chat.CreateDirectConversation(talkUser, "sttc")).CreatedChannel;

--- a/c-sharp-chat/PubnubChatApi/PubNubChatApi.Tests/MembershipTests.cs
+++ b/c-sharp-chat/PubnubChatApi/PubNubChatApi.Tests/MembershipTests.cs
@@ -85,10 +85,13 @@ public class MembershipTests
     [Test]
     public async Task TestInvite()
     {
-        var testChannel = TestUtils.AssertOperation(await chat.CreateGroupConversation([user], "test_invite_group_channel")).CreatedChannel;
+        var testChannel = TestUtils.AssertOperation(await chat.CreateGroupConversation([user], Guid.NewGuid().ToString())).CreatedChannel;
         var testUser = await chat.GetOrCreateUser("test_invite_user");
         var returnedMembership = TestUtils.AssertOperation(await testChannel.Invite(testUser));
-        Assert.True(returnedMembership.ChannelId == testChannel.Id && returnedMembership.UserId == testUser.Id);
+        Assert.True(returnedMembership.ChannelId == testChannel.Id && returnedMembership.UserId == testUser.Id && returnedMembership.MembershipData.Status == "pending");
+        
+        //Cleanup
+        await testChannel.Delete();
     }
 
     [Test]
@@ -106,6 +109,7 @@ public class MembershipTests
             returnedMemberships.Count == 2 &&
             returnedMemberships.Any(x => x.UserId == secondUser.Id && x.ChannelId == testChannel.Id) &&
             returnedMemberships.Any(x => x.UserId == thirdUser.Id && x.ChannelId == testChannel.Id));
+        Assert.True(returnedMemberships.All(x => x.MembershipData.Status == "pending"));
     }
 
     [Test]

--- a/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Channel.cs
+++ b/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Channel.cs
@@ -1173,6 +1173,7 @@ namespace PubnubChatApi
         /// to the channel.
         /// </para>
         /// </summary>
+        /// <param name="filter">The filter parameter. Note that it will always contain "status == \"pending\"" in the end request.</param>
         /// <param name="sort">The sort parameter.</param>
         /// <param name="limit">The maximum amount of the memberships received.</param>
         /// <param name="page">The page object for pagination.</param>
@@ -1188,10 +1189,15 @@ namespace PubnubChatApi
         /// </code>
         /// </example>
         /// <seealso cref="Membership"/>
-        public async Task<ChatOperationResult<MembersResponseWrapper>> GetInvitees(string sort = "", int limit = 0,
+        public async Task<ChatOperationResult<MembersResponseWrapper>> GetInvitees(string filter = "", string sort = "", int limit = 0,
             PNPageObject page = null)
         {
-            return await chat.GetChannelMemberships(Id, "status == \"pending\"", sort, limit, page).ConfigureAwait(false);
+            var finalFilter = "status == \"pending\"";
+            if (!string.IsNullOrEmpty(filter))
+            {
+                finalFilter = $"{filter} && {finalFilter}";
+            }
+            return await chat.GetChannelMemberships(Id, finalFilter, sort, limit, page).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Channel.cs
+++ b/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Channel.cs
@@ -1148,7 +1148,7 @@ namespace PubnubChatApi
         /// <param name="sort">The sort parameter.</param>
         /// <param name="limit">The maximum amount of the memberships received.</param>
         /// <param name="page">The page object for pagination.</param>
-        /// <returns>A ChatOperationResult containing the list of the <c>Membership</c> objects.</returns>
+        /// <returns>A ChatOperationResult containing a wrapper object with the list of the <c>Membership</c> objects.</returns>
         /// <example>
         /// <code>
         /// var channel = //...
@@ -1164,6 +1164,34 @@ namespace PubnubChatApi
             PNPageObject page = null)
         {
             return await chat.GetChannelMemberships(Id, filter, sort, limit, page).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the list of the <c>Membership</c> objects which have a Status of "pending".
+        /// <para>
+        /// Gets the list of the <c>Membership</c> objects that represent the users that are invited 
+        /// to the channel.
+        /// </para>
+        /// </summary>
+        /// <param name="sort">The sort parameter.</param>
+        /// <param name="limit">The maximum amount of the memberships received.</param>
+        /// <param name="page">The page object for pagination.</param>
+        /// <returns>A ChatOperationResult containing a wrapper object with the list of the <c>Membership</c> objects.</returns>
+        /// <example>
+        /// <code>
+        /// var channel = //...
+        /// var result = await channel.GetInvitees(limit: 10);
+        /// var invites = result.Result.Memberships;
+        /// foreach (var invited in invites) {
+        ///   Console.WriteLine($"Invited user: {invited.UserId}");
+        /// }
+        /// </code>
+        /// </example>
+        /// <seealso cref="Membership"/>
+        public async Task<ChatOperationResult<MembersResponseWrapper>> GetInvitees(string sort = "", int limit = 0,
+            PNPageObject page = null)
+        {
+            return await chat.GetChannelMemberships(Id, "status == \"pending\"", sort, limit, page).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Chat.cs
+++ b/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Chat.cs
@@ -357,10 +357,10 @@ namespace PubnubChatApi
                 new()
                 {
                     Channel = channelId,
+                    Status = "pending"
                     //TODO: these too here?
                     //TODO: again, should ChatMembershipData from Create(...)Channel also be passed here?
                     /*Custom = ,
-                    Status = ,
                     Type = */
                 }
             }).ExecuteAsync().ConfigureAwait(false);
@@ -380,7 +380,10 @@ namespace PubnubChatApi
             var inviteEventPayload = $"{{\"channelType\": \"{channel.Result.Type}\", \"channelId\": {channelId}}}";
             await EmitEvent(PubnubChatEventType.Invite, userId, inviteEventPayload).ConfigureAwait(false);
             
-            var newMembership = new Membership(this, userId, channelId, new ChatMembershipData());
+            var newMembership = new Membership(this, userId, channelId, new ChatMembershipData()
+            {
+                Status = "pending"
+            });
             await newMembership.SetLastReadMessageTimeToken(ChatUtils.TimeTokenNow()).ConfigureAwait(false);
 
             result.Result = newMembership;
@@ -413,7 +416,7 @@ namespace PubnubChatApi
                         PNChannelMemberField.UUID_STATUS
                     })
                 //TODO: again, should ChatMembershipData from Create(...)Channel  also be passed here?
-                .Uuids(users.Select(x => new PNChannelMember() { Custom = x.CustomData, Uuid = x.Id }).ToList())
+                .Uuids(users.Select(x => new PNChannelMember() { Custom = x.CustomData, Uuid = x.Id, Status = "pending"}).ToList())
                 .ExecuteAsync().ConfigureAwait(false);
             
             if (result.RegisterOperation(inviteResponse))

--- a/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Data/ChatMembershipData.cs
+++ b/c-sharp-chat/PubnubChatApi/PubnubChatApi/Entities/Data/ChatMembershipData.cs
@@ -15,8 +15,8 @@ namespace PubnubChatApi
     public class ChatMembershipData
     {
         public Dictionary<string, object> CustomData { get; set; } = new();
-        public string Status { get; set; }
-        public string Type { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
         
         public static implicit operator ChatMembershipData(PNChannelMembersItemResult membersItem)
         {

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Channel.cs
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Channel.cs
@@ -1173,6 +1173,7 @@ namespace PubnubChatApi
         /// to the channel.
         /// </para>
         /// </summary>
+        /// <param name="filter">The filter parameter. Note that it will always contain "status == \"pending\"" in the end request.</param>
         /// <param name="sort">The sort parameter.</param>
         /// <param name="limit">The maximum amount of the memberships received.</param>
         /// <param name="page">The page object for pagination.</param>
@@ -1188,10 +1189,15 @@ namespace PubnubChatApi
         /// </code>
         /// </example>
         /// <seealso cref="Membership"/>
-        public async Task<ChatOperationResult<MembersResponseWrapper>> GetInvitees(string sort = "", int limit = 0,
+        public async Task<ChatOperationResult<MembersResponseWrapper>> GetInvitees(string filter = "", string sort = "", int limit = 0,
             PNPageObject page = null)
         {
-            return await chat.GetChannelMemberships(Id, "status == \"pending\"", sort, limit, page).ConfigureAwait(false);
+            var finalFilter = "status == \"pending\"";
+            if (!string.IsNullOrEmpty(filter))
+            {
+                finalFilter = $"{filter} && {finalFilter}";
+            }
+            return await chat.GetChannelMemberships(Id, finalFilter, sort, limit, page).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Channel.cs
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Channel.cs
@@ -1148,7 +1148,7 @@ namespace PubnubChatApi
         /// <param name="sort">The sort parameter.</param>
         /// <param name="limit">The maximum amount of the memberships received.</param>
         /// <param name="page">The page object for pagination.</param>
-        /// <returns>A ChatOperationResult containing the list of the <c>Membership</c> objects.</returns>
+        /// <returns>A ChatOperationResult containing a wrapper object with the list of the <c>Membership</c> objects.</returns>
         /// <example>
         /// <code>
         /// var channel = //...
@@ -1164,6 +1164,34 @@ namespace PubnubChatApi
             PNPageObject page = null)
         {
             return await chat.GetChannelMemberships(Id, filter, sort, limit, page).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the list of the <c>Membership</c> objects which have a Status of "pending".
+        /// <para>
+        /// Gets the list of the <c>Membership</c> objects that represent the users that are invited 
+        /// to the channel.
+        /// </para>
+        /// </summary>
+        /// <param name="sort">The sort parameter.</param>
+        /// <param name="limit">The maximum amount of the memberships received.</param>
+        /// <param name="page">The page object for pagination.</param>
+        /// <returns>A ChatOperationResult containing a wrapper object with the list of the <c>Membership</c> objects.</returns>
+        /// <example>
+        /// <code>
+        /// var channel = //...
+        /// var result = await channel.GetInvitees(limit: 10);
+        /// var invites = result.Result.Memberships;
+        /// foreach (var invited in invites) {
+        ///   Console.WriteLine($"Invited user: {invited.UserId}");
+        /// }
+        /// </code>
+        /// </example>
+        /// <seealso cref="Membership"/>
+        public async Task<ChatOperationResult<MembersResponseWrapper>> GetInvitees(string sort = "", int limit = 0,
+            PNPageObject page = null)
+        {
+            return await chat.GetChannelMemberships(Id, "status == \"pending\"", sort, limit, page).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Chat.cs
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Chat.cs
@@ -357,10 +357,10 @@ namespace PubnubChatApi
                 new()
                 {
                     Channel = channelId,
+                    Status = "pending"
                     //TODO: these too here?
                     //TODO: again, should ChatMembershipData from Create(...)Channel also be passed here?
                     /*Custom = ,
-                    Status = ,
                     Type = */
                 }
             }).ExecuteAsync().ConfigureAwait(false);
@@ -380,7 +380,10 @@ namespace PubnubChatApi
             var inviteEventPayload = $"{{\"channelType\": \"{channel.Result.Type}\", \"channelId\": {channelId}}}";
             await EmitEvent(PubnubChatEventType.Invite, userId, inviteEventPayload).ConfigureAwait(false);
             
-            var newMembership = new Membership(this, userId, channelId, new ChatMembershipData());
+            var newMembership = new Membership(this, userId, channelId, new ChatMembershipData()
+            {
+                Status = "pending"
+            });
             await newMembership.SetLastReadMessageTimeToken(ChatUtils.TimeTokenNow()).ConfigureAwait(false);
 
             result.Result = newMembership;
@@ -413,7 +416,7 @@ namespace PubnubChatApi
                         PNChannelMemberField.UUID_STATUS
                     })
                 //TODO: again, should ChatMembershipData from Create(...)Channel  also be passed here?
-                .Uuids(users.Select(x => new PNChannelMember() { Custom = x.CustomData, Uuid = x.Id }).ToList())
+                .Uuids(users.Select(x => new PNChannelMember() { Custom = x.CustomData, Uuid = x.Id, Status = "pending"}).ToList())
                 .ExecuteAsync().ConfigureAwait(false);
             
             if (result.RegisterOperation(inviteResponse))

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Data/ChatMembershipData.cs
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/PubnubChatApi/Entities/Data/ChatMembershipData.cs
@@ -15,8 +15,8 @@ namespace PubnubChatApi
     public class ChatMembershipData
     {
         public Dictionary<string, object> CustomData { get; set; } = new();
-        public string Status { get; set; }
-        public string Type { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
         
         public static implicit operator ChatMembershipData(PNChannelMembersItemResult membersItem)
         {

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/UnityChatPNSDKSource.cs
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/Runtime/UnityChatPNSDKSource.cs
@@ -5,7 +5,7 @@ namespace PubnubChatApi
 {
     public class UnityChatPNSDKSource : IPNSDKSource
     {
-        private const string build = "1.1.1";
+        private const string build = "1.2.0";
 
         private string GetPlatformString()
         {

--- a/unity-chat/PubnubChatUnity/Assets/PubnubChat/package.json
+++ b/unity-chat/PubnubChatUnity/Assets/PubnubChat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.pubnub.pubnubchat",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "displayName": "Pubnub Chat",
   "description": "PubNub Unity Chat SDK",
   "unity": "2022.3",

--- a/unity-chat/PubnubChatUnity/Assets/Snippets/ChannelSample.cs
+++ b/unity-chat/PubnubChatUnity/Assets/Snippets/ChannelSample.cs
@@ -48,4 +48,26 @@ public class ChannelSample
         }
         // snippet.end
     }
+    
+    public static async Task GetInviteesExample()
+    {
+        // snippet.get_invitees_example
+        // Get or create a channel
+        var channelResult = await chat.GetChannel("my_channel");
+        if (channelResult.Error)
+        {
+            Debug.LogError($"Could not fetch channel! Error: {channelResult.Exception.Message}");
+        }
+        var channel = channelResult.Result;
+        var getInvitees = await channel.GetInvitees();
+        if (getInvitees.Error)
+        {
+            Debug.LogError($"Could not fetch invitees! Error: {getInvitees.Exception.Message}");
+        }
+        foreach (var membership in getInvitees.Result.Memberships)
+        {
+            Debug.Log($"User {membership.UserId} has is invited to channel {membership.ChannelId}");
+        }
+        // snippet.end
+    }
 }


### PR DESCRIPTION
feat: distinguish invite memberships

Memberships generated from Invite methods now have Status = pending and can be filtered out in GetMemberships()

refactor: deprecated old streaming methods

Changed SetListening(...) and AddListenerTo(...) methods to align with other Chat SDKs. New methods are use the Stream and StreamOn naming convetions

feat: added and implemented ChatEntityChangeType enum

Added new overloads for update related methods and events so that they now use ChatEntityChangeType to convey the type of update.